### PR TITLE
Update Call.js

### DIFF
--- a/src/verto/Call.js
+++ b/src/verto/Call.js
@@ -19,7 +19,7 @@ export default class Call {
     this.direction = direction;
     this.verto = verto;
     this.params = {
-      callID: generateGUID(),
+      //callID: generateGUID(),
       useVideo: verto.options.useVideo,
       useStereo: verto.options.useStereo,
       screenShare: false,
@@ -43,6 +43,9 @@ export default class Call {
 
     this.lastState = ENUM.state.new;
     this.state = this.lastState;
+    
+    if(this.params.callID === undefined)
+      this.params.callID = generateGUID();
 
     this.verto.calls[this.params.callID] = this;
 
@@ -230,6 +233,7 @@ export default class Call {
     this.verto.callbacks.onCallStateChange({
       previous: this.lastState,
       current: this.state,
+      callID: this.params.callID
     });
 
     const speaker = this.params.useSpeak;

--- a/src/verto/VertoClient.js
+++ b/src/verto/VertoClient.js
@@ -551,6 +551,8 @@ export default class VertinhoClient {
   }
 
   destroy() {
+    if (this.retryingTimer)
+      clearTimeout(this.retryingTimer);
     if (this.socketReady()) {
       this.webSocket.close();
       this.purge();
@@ -561,8 +563,6 @@ export default class VertinhoClient {
     if (this.webSocket)
       delete this.webSocket;
     this.webSocket = null;
-    if (this.retryingTimer)
-      clearTimeout(this.retryingTimer);
   }
 
   hangup(callId) {

--- a/src/verto/VertoClient.js
+++ b/src/verto/VertoClient.js
@@ -149,11 +149,10 @@ export default class VertinhoClient {
   }
 
   socketReady() {
-    if (this.webSocket === null || this.webSocket.readyState > 1) {
+    if (this.webSocket != null && this.webSocket.readyState === 1)
+      return true;
+    else
       return false;
-    }
-
-    return true;
   }
 
   purge() {

--- a/src/webrtc/VertoRTC.js
+++ b/src/webrtc/VertoRTC.js
@@ -274,6 +274,8 @@ export default class VertoRTC {
     }
 
     const mediaConstraints = this.getMediaParams();
+    if(typeof mediaConstraints.audio != 'boolean')
+      mediaConstraints.audio = true;
     mediaDevices
       .getUserMedia(mediaConstraints)
       .then(stream => {

--- a/src/webrtc/VertoRTC.js
+++ b/src/webrtc/VertoRTC.js
@@ -274,8 +274,6 @@ export default class VertoRTC {
     }
 
     const mediaConstraints = this.getMediaParams();
-    if(typeof mediaConstraints.audio != 'boolean')
-      mediaConstraints.audio = true;
     mediaDevices
       .getUserMedia(mediaConstraints)
       .then(stream => {


### PR DESCRIPTION
You can choose whether to pass the callId or create it as usual. This is to facilitate calls with an external service while keeping the same callId. In onCallStateChange I pass the callId to better manage multicalls.